### PR TITLE
Expose PasswordStats.letters_lowercase by adding a lowercase test

### DIFF
--- a/password_strength/tests.py
+++ b/password_strength/tests.py
@@ -25,6 +25,13 @@ class Uppercase(ATest):
         return ps.letters_uppercase >= self.count
 
 
+class Lowercase(Uppercase):
+    """ Test whether the password has >= `count` lowercase characters """
+
+    def test(self, ps):
+        return ps.letters_lowercase >= self.count
+
+
 class Numbers(Uppercase):
     """ Test whether the password has >= `count` numeric characters """
 

--- a/tests/policy-test.py
+++ b/tests/policy-test.py
@@ -10,6 +10,7 @@ class PolicyTest(unittest.TestCase):
         policy = PasswordPolicy.from_names(
             length=8,
             uppercase=2,
+            lowercase=2,
             numbers=2,
             special=2,
             nonletters=2,
@@ -19,10 +20,12 @@ class PolicyTest(unittest.TestCase):
         )
 
         passwords = {
-            'qazwsx':           {'length', 'uppercase', 'numbers', 'special', 'nonletters', 'nonletterslc', 'entropybits', 'strength'},
-            'qazwsxrfv':        {          'uppercase', 'numbers', 'special', 'nonletters', 'nonletterslc', 'entropybits', 'strength'},
-            'qazwsxrfvTG':      {                       'numbers', 'special', 'nonletters',                                          },
-            'qazwsxrfvTG94':    {                                  'special',                                                        },
+            'QAZWSX':           {'length',              'lowercase', 'numbers', 'special', 'nonletters',                 'entropybits', 'strength'},
+            'QAZWSx':           {'length',              'lowercase', 'numbers', 'special', 'nonletters',                 'entropybits', 'strength'},
+            'qazwsx':           {'length', 'uppercase',              'numbers', 'special', 'nonletters', 'nonletterslc', 'entropybits', 'strength'},
+            'qazwsxrfv':        {          'uppercase',              'numbers', 'special', 'nonletters', 'nonletterslc', 'entropybits', 'strength'},
+            'qazwsxrfvTG':      {                                    'numbers', 'special', 'nonletters',                                          },
+            'qazwsxrfvTG94':    {                                               'special',                                                        },
             'qazwsxrfvTG94@$':  set(),
         }
 


### PR DESCRIPTION
This adds support for password policies that explicitly require a certain amount of lowercase letters to be present in a password.