### PR TITLE
str dunders has been added for ATest objects.

### DIFF
--- a/password_strength/tests.py
+++ b/password_strength/tests.py
@@ -13,6 +13,9 @@ class Length(ATest):
     def test(self, ps):
         return ps.length >= self.length
 
+    def __str__(self):
+        return "Your password must be a minimum of {} characters.".format(self.length)
+
 
 class Uppercase(ATest):
     """ Test whether the password has >= `count` uppercase characters """
@@ -24,6 +27,9 @@ class Uppercase(ATest):
     def test(self, ps):
         return ps.letters_uppercase >= self.count
 
+    def __str__(self):
+        return "Your password must contain a minimum of {} uppercase characters.".format(self.count)
+
 
 class Numbers(Uppercase):
     """ Test whether the password has >= `count` numeric characters """
@@ -31,12 +37,18 @@ class Numbers(Uppercase):
     def test(self, ps):
         return ps.numbers >= self.count
 
+    def __str__(self):
+        return "Your password must contain a minimum of {} number.".format(self.count)
+
 
 class Special(Uppercase):
     """ Test whether the password has >= `count` special characters """
 
     def test(self, ps):
         return ps.special_characters >= self.count
+
+    def __str__(self):
+        return "Your password must contain a minimum of {} special characters.".format(self.count)
 
 
 class NonLetters(Uppercase):
@@ -46,6 +58,9 @@ class NonLetters(Uppercase):
         non_letters = ps.length - ps.letters
         return non_letters >= self.count
 
+    def __str__(self):
+        return "Your password must contain a minimum of {} non-letter characters.".format(self.count)
+
 
 class NonLettersLc(Uppercase):
     """ Test whether the password has >= `count` non-lowercase characters """
@@ -53,6 +68,9 @@ class NonLettersLc(Uppercase):
     def test(self, ps):
         non_lowercase_letters = ps.length - ps.letters_lowercase
         return non_lowercase_letters >= self.count
+
+    def __str__(self):
+        return "Your password must contain a minimum of {} non-lowercase characters.".format(self.count)
 
 
 class EntropyBits(ATest):
@@ -69,6 +87,9 @@ class EntropyBits(ATest):
 
     def test(self, ps):
         return ps.entropy_bits >= self.bits
+    
+    def __str__(self):
+        return "Your password must have a minimum of {} entropy bits.".format(self.bits)
 
 
 class Strength(ATest):
@@ -85,3 +106,6 @@ class Strength(ATest):
 
     def test(self, ps):
         return (1 - ps.weakness_factor) * ps.strength(self.weak_bits) >= self.strength
+
+    def __str__(self):
+        return "Your password is not strong enough."


### PR DESCRIPTION
Hi, I have added str dunders that could be useful for Python web developers. 

```python

# policy.py

from password_strength import PasswordPolicy

password_policy = PasswordPolicy.from_names(
    length=8
)

```


```python

# serializers.py

from .models import User
from .policy import password_policy
from rest_framework import serializers
from django.contrib.auth.hashers import make_password


class UserSerializer(serializers.ModelSerializer):
    def validate(self, data):
        errs = password_policy.test(data["password"])
        if errs:
            raise serializers.ValidationError(
                {"password": [str(err) for err in errs]})
        return data

    class Meta:
        model = User
        fields = "__all__"

    def create(self, validated_data):
        validated_data["is_active"] = True
        validated_data["password"] = make_password(validated_data["password"])
        return super(UserSerializer, self).create(validated_data)
```

An example response is from API.

```js
{
    "password": [
        "Your password must be a minimum of 8 characters."
    ]
}
```
